### PR TITLE
Remove dependency on "services" database

### DIFF
--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -702,7 +702,7 @@ my_bool _mariadb_set_conf_option(MYSQL *mysql, const char *config_option, const 
   {
     int i;
     char *c;
-    
+
     /* CONC-395: replace underscore "_" by dash "-" */
     while ((c= strchr(config_option, '_')))
       *c= '-';
@@ -1507,7 +1507,7 @@ MYSQL *mthd_my_real_connect(MYSQL *mysql, const char *host, const char *user,
   {
     net->last_errno=CR_CANT_READ_CHARSET;
     sprintf(net->last_error,ER(net->last_errno),
-      mysql->options.charset_name ? mysql->options.charset_name : 
+      mysql->options.charset_name ? mysql->options.charset_name :
                                     MARIADB_DEFAULT_CHARSET,
       "compiled_in");
     goto error;
@@ -2915,7 +2915,7 @@ mysql_optionsv(MYSQL *mysql,enum mysql_option option, ...)
         }
       }
       /* check if key is already in buffer */
-      p= (uchar *)hash_search(&mysql->options.extension->userdata, 
+      p= (uchar *)hash_search(&mysql->options.extension->userdata,
                               (uchar *)key,
                               (uint)strlen(key));
       if (p)
@@ -3543,10 +3543,6 @@ static void mysql_once_init()
     char *env;
 
     mysql_port = MARIADB_PORT;
-    if ((serv_ptr = getservbyname("mysql", "tcp")))
-      mysql_port = (uint)ntohs((ushort)serv_ptr->s_port);
-    if ((env = getenv("MYSQL_TCP_PORT")))
-      mysql_port =(uint)atoi(env);
   }
   if (!mysql_unix_port)
   {


### PR DESCRIPTION
Default MySQL port was dependent on a file in filesystem. This is non-obvious and not secure, it makes the application not self-contained.