### PR TITLE
Check SSL_get_error() on SSL_read() when returns 0 (like man says)

### DIFF
--- a/libmariadb/secure/openssl.c
+++ b/libmariadb/secure/openssl.c
@@ -726,7 +726,7 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   int rc;
   MARIADB_PVIO *pvio= ctls->pvio;
 
-  while ((rc= SSL_read((SSL *)ctls->ssl, (void *)buffer, (int)length)) < 0)
+  while ((rc= SSL_read((SSL *)ctls->ssl, (void *)buffer, (int)length)) <= 0)
   {
     int error= SSL_get_error((SSL *)ctls->ssl, rc);
     if (error != SSL_ERROR_WANT_READ)


### PR DESCRIPTION
**Note, that this is a cherry pick from upstream, hence no PR in upstream**