### PR TITLE
OpenSSL timeout fix: (backport)

### DIFF
--- a/libmariadb/secure/gnutls.c
+++ b/libmariadb/secure/gnutls.c
@@ -1282,7 +1282,7 @@ ssize_t ma_tls_read(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   {
     if (rc != GNUTLS_E_AGAIN && rc != GNUTLS_E_INTERRUPTED)
       return rc;
-    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, pvio->timeout[PVIO_READ_TIMEOUT]) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, TRUE, 5) < 1)
       return rc;
   }
   return rc;
@@ -1297,7 +1297,7 @@ ssize_t ma_tls_write(MARIADB_TLS *ctls, const uchar* buffer, size_t length)
   {
     if (rc != GNUTLS_E_AGAIN && rc != GNUTLS_E_INTERRUPTED)
       return rc;
-    if (pvio->methods->wait_io_or_timeout(pvio, FALSE, pvio->timeout[PVIO_WRITE_TIMEOUT]) < 1)
+    if (pvio->methods->wait_io_or_timeout(pvio, FALSE, 5) < 1)
       return rc;
   }
   return rc;


### PR DESCRIPTION
Since timeout was already set via setsockopt, we call wait_io_or_timeout() with a very small timeout (5ms) to get a more precise errno, which is used by OpenSSL's error function.

Note (azat): initial patch (https://github.com/mariadb-corporation/mariadb-connector-c/pull/250) was wrong:

  Georg Richter:

    > Timeouts were already set via setsockopt() function before. Since
    > the socket already timeout, it will wait andother read/write timeout
    > period.  Instead of, we should get wait_io_or_timeout with a timeout of
    > a few milliseconds to get the correct errno.

And got reverted in (https://github.com/mariadb-corporation/mariadb-connector-c/pull/253).

Upstream: https://github.com/mariadb-corporation/mariadb-connector-c/commit/a6fd09f1df2bfe00759fddfc23028dc0161d69e9